### PR TITLE
Increase docker timeout

### DIFF
--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -196,7 +196,7 @@ class EventStreamRuntime(Runtime):
     @staticmethod
     def _init_docker_client() -> docker.DockerClient:
         try:
-            return docker.from_env()
+            return docker.from_env(timeout=300)
         except Exception as ex:
             logger.error(
                 'Launch docker client failed. Please make sure you have installed docker and started docker desktop/daemon.'


### PR DESCRIPTION
Increases the Docker timeout from 1 minute to 5 minutes so that large-ish containers don't timeout when being created.