### PR TITLE
Log LLM messages for debugging

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -205,16 +205,17 @@ class CodeActAgent(Agent):
         }
 
         response = self.llm.completion(**params)
-        parsed_response = self.action_parser.parse(response)
+        parsed_action = self.action_parser.parse(response)
 
         # DEBUG: save llm messages to a file
         # we'll also add the parsed response to the end of the messages
+        parsed_str = self.action_parser.parse_response(response)
         response_message = {
             "role": "assistant",
             "content": [
                 {
                     "type": "text",
-                    "text": parsed_response,
+                    "text": parsed_str,
                 }
             ]
         }
@@ -228,7 +229,7 @@ class CodeActAgent(Agent):
                 for content in message["content"]:
                     f.write(content["text"] + "\n")
 
-        return parsed_response
+        return parsed_action
 
     def _get_messages(self, state: State) -> list[Message]:
         messages: list[Message] = [

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -203,7 +203,21 @@ class CodeActAgent(Agent):
                 '</execute_browse>',
             ],
         }
+
+        response = self.llm.completion(**params)
+        parsed_response = self.action_parser.parse(response)
+
         # DEBUG: save llm messages to a file
+        # we'll also add the parsed response to the end of the messages
+        response_message = {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": parsed_response,
+                }
+            ]
+        }
         with open("/home/logs/llm_messages.json", "w") as f:
             import json
             json.dump(params["messages"], f, indent=2)
@@ -213,9 +227,7 @@ class CodeActAgent(Agent):
                 for content in message["content"]:
                     f.write(content["text"] + "\n")
 
-        response = self.llm.completion(**params)
-
-        return self.action_parser.parse(response)
+        return parsed_response
 
     def _get_messages(self, state: State) -> list[Message]:
         messages: list[Message] = [

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -218,11 +218,12 @@ class CodeActAgent(Agent):
                 }
             ]
         }
+        messages = params["messages"] + [response_message]
         with open("/home/logs/llm_messages.json", "w") as f:
             import json
-            json.dump(params["messages"], f, indent=2)
+            json.dump(messages, f, indent=2)
         with open("/home/logs/llm_messages.txt", "w") as f:
-            for message in params["messages"]:
+            for message in messages:
                 f.write("-" * 100 + message["role"] + "\n")
                 for content in message["content"]:
                     f.write(content["text"] + "\n")

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -203,6 +203,10 @@ class CodeActAgent(Agent):
                 '</execute_browse>',
             ],
         }
+        # DEBUG: save llm messages to a file
+        with open("/home/logs/llm_messages.json", "w") as f:
+            import json
+            json.dump(params["messages"], f, indent=2)
 
         response = self.llm.completion(**params)
 

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -207,6 +207,10 @@ class CodeActAgent(Agent):
         with open("/home/logs/llm_messages.json", "w") as f:
             import json
             json.dump(params["messages"], f, indent=2)
+        with open("/home/logs/llm_messages.txt", "w") as f:
+            for message in params["messages"]:
+                f.write("-" * 100 + message["role"] + "\n")
+                f.write(message["content"][0]["text"] + "\n")
 
         response = self.llm.completion(**params)
 

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -210,7 +210,8 @@ class CodeActAgent(Agent):
         with open("/home/logs/llm_messages.txt", "w") as f:
             for message in params["messages"]:
                 f.write("-" * 100 + message["role"] + "\n")
-                f.write(message["content"][0]["text"] + "\n")
+                for content in message["content"]:
+                    f.write(content["text"] + "\n")
 
         response = self.llm.completion(**params)
 


### PR DESCRIPTION
Saves `llm_messages.json` and `llm_messages.txt` to the `LOGS_DIR`, showing the full message context which is presented to the Agent's LLM on each turn.