### PR TITLE
Disable AgentFinishAction

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -297,7 +297,7 @@ class CodeActAgent(Agent):
             None,
         )
         if latest_user_message:
-            reminder_text = f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete your work. Please spend all available time to complete as much of the tasks as possible, and double-check your work if you have time left over.'
+            reminder_text = f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete your work. Please spend all available time to complete as many of the tasks as possible, and double-check your work if you have time left over.'
             latest_user_message.content.append(TextContent(text=reminder_text))
 
         return messages

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -297,7 +297,7 @@ class CodeActAgent(Agent):
             None,
         )
         if latest_user_message:
-            reminder_text = f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete the task. When finished reply with <finish></finish>.'
+            reminder_text = f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete your work. Please spend all available time to complete as much of the tasks as possible, and double-check your work if you have time left over.'
             latest_user_message.content.append(TextContent(text=reminder_text))
 
         return messages

--- a/openhands/agenthub/codeact_agent/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/system_prompt.j2
@@ -40,7 +40,6 @@ IMPORTANT:
 Responses should be concise.
 The assistant should attempt fewer things at a time instead of putting too many commands OR too much code in one "execute" block.
 Include ONLY ONE <execute_ipython>, <execute_bash>, or <execute_browse> per response, unless the assistant is finished with the task or needs more input or action from the user in order to proceed.
-If the assistant is finished with the task you MUST include <finish></finish> in your response.
 IMPORTANT: Execute code using <execute_ipython>, <execute_bash>, or <execute_browse> whenever possible.
 The assistant should utilize full file paths and the `pwd` command to prevent path-related errors.
 The assistant MUST NOT apologize to the user or thank the user after running commands or editing files. It should only address the user in response to an explicit message from the user, or to ask for more information.

--- a/openhands/agenthub/codeact_agent/user_prompt.j2
+++ b/openhands/agenthub/codeact_agent/user_prompt.j2
@@ -214,7 +214,6 @@ Observation:
 
 ASSISTANT:
 The server is running on port 5000 with PID 126. You can access the list of numbers in a table format by visiting http://127.0.0.1:5000. Let me know if you have any further requests!
-<finish></finish>
 
 --- END OF EXAMPLE ---
 {% endset %}


### PR DESCRIPTION
- Agent always finished its runs very prematurely; we simply remove its option to end the run voluntarily to mitigate this.
- In practice, this is achieved by removing any mention of the `<finish></finish>` flag anywhere in its prompt (this flag is used to trigger the AgentFinishAction, so if the agent doesn't know about this flag, it can't end the run).