### PR TITLE
sanitise action_str with repr() in BrowsingActionParserMessage to prevent it crashing

### DIFF
--- a/openhands/agenthub/browsing_agent/response_parser.py
+++ b/openhands/agenthub/browsing_agent/response_parser.py
@@ -50,7 +50,7 @@ class BrowsingActionParserMessage(ActionParser):
         return '```' not in action_str
 
     def parse(self, action_str: str) -> Action:
-        msg = f'send_msg_to_user("""{action_str}""")'
+        msg = "send_msg_to_user({})".format(repr(action_str))
         return BrowseInteractiveAction(
             browser_actions=msg,
             thought=action_str,


### PR DESCRIPTION
Previously we'd get issues such as

```
  File "/home/agent/openhands/agenthub/browsing_agent/response_parser.py", line 99, in parse
    tree = ast.parse(sub_action)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/agent/lib/python3.12/ast.py", line 52, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<unknown>", line 1
    send_msg_to_user("""import anthropic
                     ^
SyntaxError: unterminated triple-quoted string literal (detected at line 1)
[92m20:06:34 - openhands:ERROR[0m: agent_controller.py:161 - Error while running the agent: unterminated triple-quoted string literal (detected at line 1) (<unknown>, line 1)
```